### PR TITLE
fix(ResourceType): fix load to return Promise

### DIFF
--- a/src/resource-type.js
+++ b/src/resource-type.js
@@ -14,7 +14,7 @@ export class ResourceType {
   * @return {Promise} Returns a promise for itself, resolving when all dependent resources are loaded.
   */
   load(container, target){ 
-    return this;
+    return Promise.resolve(this);
   }
 
   /**


### PR DESCRIPTION
the load method is supposed to return a promise that resolves to the object, not the object itself