### PR TITLE
fix(metadata): Use correct import for core-js

### DIFF
--- a/src/origin.js
+++ b/src/origin.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 
 var originStorage = new Map(),
     unknownOrigin = Object.freeze({moduleId:undefined,moduleMember:undefined});


### PR DESCRIPTION
We were previously using `import core from core-js` which generates d.ts that do not match the corejs d.ts. This is now updated to `import * as core 'core-js'`, which resolves TypeScript compilation warnings.

closes aurelia/framework#177