### PR TITLE
fix(metadata): targetKey in Reflect.defineMetadata is optional

### DIFF
--- a/src/metadata.js
+++ b/src/metadata.js
@@ -20,21 +20,21 @@ interface MetadataType {
   * @param target The target to lookup the metadata on.
   * @param targetKey The member on the target to lookup the metadata on.
   */
-  get(metadataKey: string, target: Function, targetKey: string): Object;
+  get(metadataKey: string, target: Function, targetKey?: string): Object;
   /**
   * Gets metadata specified by a key on a target, only searching the own instance.
   * @param metadataKey The key for the metadata to lookup.
   * @param target The target to lookup the metadata on.
   * @param targetKey The member on the target to lookup the metadata on.
   */
-  getOwn(metadataKey: string, target: Function, targetKey: string): Object;
+  getOwn(metadataKey: string, target: Function, targetKey?: string): Object;
   /**
   * Defines metadata specified by a key on a target.
   * @param metadataKey The key for the metadata to define.
   * @param target The target to set the metadata on.
   * @param targetKey The member on the target to set the metadata on.
   */
-  define(metadataKey: string, metadataValue: Object, target: Function, targetKey: string): void;
+  define(metadataKey: string, metadataValue: Object, target: Function, targetKey?: string): void;
   /**
   * Gets metadata specified by a key on a target, or creates an instance of the specified metadata if not found.
   * @param metadataKey The key for the metadata to lookup or create.
@@ -42,7 +42,7 @@ interface MetadataType {
   * @param target The target to lookup or create the metadata on.
   * @param targetKey The member on the target to lookup or create the metadata on.
   */
-  getOrCreateOwn(metadataKey: string, Type: Function, target: Function, targetKey: string): Object;
+  getOrCreateOwn(metadataKey: string, Type: Function, target: Function, targetKey?: string): Object;
 }
 
 /**
@@ -52,19 +52,19 @@ export const metadata: MetadataType = {
   resource: 'aurelia:resource',
   paramTypes: 'design:paramtypes',
   properties: 'design:properties',
-  get(metadataKey: string, target: Function, targetKey: string): Object {
+  get(metadataKey: string, target: Function, targetKey?: string): Object {
     if (!target) { return undefined; }
     let result = metadata.getOwn(metadataKey, target, targetKey);
     return result === undefined ? metadata.get(metadataKey, Object.getPrototypeOf(target), targetKey) : result;
   },
-  getOwn(metadataKey: string, target: Function, targetKey: string): Object {
+  getOwn(metadataKey: string, target: Function, targetKey?: string): Object {
     if (!target) { return undefined; }
     return Reflect.getOwnMetadata(metadataKey, target, targetKey);
   },
-  define(metadataKey: string, metadataValue: Object, target: Function, targetKey: string): void {
+  define(metadataKey: string, metadataValue: Object, target: Function, targetKey?: string): void {
     Reflect.defineMetadata(metadataKey, metadataValue, target, targetKey);
   },
-  getOrCreateOwn(metadataKey: string, Type: Function, target: Function, targetKey: string): Object {
+  getOrCreateOwn(metadataKey: string, Type: Function, target: Function, targetKey?: string): Object {
     let result = metadata.getOwn(metadataKey, target, targetKey);
 
     if (result === undefined) {


### PR DESCRIPTION
as currently it isn't marked optional for typescript "undefined" is used for all if no key is given. That's not working. 

alternatively setting a default as  `targetKey:string = target.name` would work