### PR TITLE
IE11 cross origin frame 'Access Denied' error in Origin.get

### DIFF
--- a/src/origin.js
+++ b/src/origin.js
@@ -38,10 +38,15 @@ export class Origin {
       PLATFORM.eachModule((key, value) => {
         if (typeof value === 'object') {
           for (let name in value) {
-            let exp = value[name];
-            if (exp === fn) {
-              originStorage.set(fn, origin = new Origin(key, name));
-              return true;
+            try {
+              let exp = value[name];
+              if (exp === fn) {
+                originStorage.set(fn, origin = new Origin(key, name));
+                return true;
+              }
+            } catch (e) {
+              // IE11 in cross origin frame fails when accessing Window['frameElement'] with Access Denied script error.
+              // Window gets exported from webpack buildin/global.js.
             }
           }
         }

--- a/test/origin.spec.js
+++ b/test/origin.spec.js
@@ -25,8 +25,9 @@ describe('origin', () => {
   });
 
   describe('get - search modules', () => {
-    let modules = {'text-file': 'abcdef', 'real-module':{name:'test', x() {return 'hey'}}};
+    let modules = undefined;
     beforeEach(()=> {
+      modules = {'text-file': 'abcdef', 'real-module':{name: 'test', x() { return 'hey' }}};
       spyOn(PLATFORM, 'eachModule').and.callFake((callback) => {
         for (let key in modules) callback(key, modules[key]);
       });
@@ -45,6 +46,13 @@ describe('origin', () => {
 
     it('but it should not search in strings', () => {
       expect(Origin.get('a').moduleId).toBe(undefined);
+    });
+
+    it('should not fail on accessing restricted/failing members', () => {
+      Object.defineProperty(modules['real-module'], 'restricted1', { get: () => { throw new Error('restricted') }, enumerable: true });
+      class Test {}
+      expect(Origin.get(Test).moduleId).toBe(undefined);
+      expect(PLATFORM.eachModule).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
IE11 in cross origin frame fails when accessing `Window['frameElement']` with 'Access Denied' script error.

Here is the fork of skeleton-navigation with a test page added reproducing the issue 'in the field' - https://github.com/Steinpilz/skeleton-navigation/tree/ie-xorigin-frame-access-denied, project 'skeleton-typescript-webpack'. Run and open http://127.0.0.1:8080/frame.html in IE11, try to navigate to the Test Page. It will fail because of `Origin.get` Aurelia requests while processing the view dynamically composed via `<compose view-model="..."`. Since we have `Window` exported as a module by webpack via buildin/global.js, `Origin.get`  enumerates its members and fails on `frameElement`.

Not quite sure if it's the proper fix though, but it seems the least disruptive one for me. The tests I've added is synthetic and expects Origin.get to handle any error, not only from Window['frameElement'].